### PR TITLE
Adding iter_vaex, to stream data from vaex.dataframe

### DIFF
--- a/creme/stream.py
+++ b/creme/stream.py
@@ -17,7 +17,11 @@ try:
 except ImportError:
     PANDAS_INSTALLED = False
 from sklearn import utils
-
+try:
+    from vaex.utils import _ensure_strings_from_expressions, _ensure_list
+    VAEX_INSTALLED = True
+except ImportError:
+    VAEX_INSTALLED = False
 
 __all__ = [
     'iter_csv',
@@ -110,6 +114,42 @@ def iter_pandas(X, y=None, **kwargs):
 
     for x, yi in iter_array(X.to_numpy(), y, **kwargs):
         yield x, yi
+
+
+def iter_vaex(X, y=None, features=None, **kwargs):
+    """Yields rows from a ``vaex.DataFrame``.
+
+    Parameters:
+        X (vaex.DataFrame): A vaex DataFrame housing the training featuers.
+        y (string or vaex.Expression): The column or expression containing the target variable.
+        features (list of strings or vaex.Expressions): A list of features used for training.
+        If None, all columns in ``X`` will be used. Features specifying in ``y`` are ignored.
+
+    Yields:
+        tuple: A pair (``x``, ``y``) where ``x`` is a dict of features and ``y`` is the target.
+    """
+
+    if VAEX_INSTALLED is not True:
+        raise ValueError('Please install vaex befor using this convenience function.')
+
+    features = _ensure_strings_from_expressions(features)
+    feature_names = features or X.get_column_names()
+
+    if y:
+        y = _ensure_strings_from_expressions(y)
+        y = _ensure_list(y)
+        feature_names = [feat for feat in feature_names if feat not in y]
+
+    multioutput = len(y) > 1
+
+    if multioutput:
+        for i in range(len(X)):
+            yield {key: X.evaluate(key, i, i+1)[0] for key in feature_names}, {key: X.evaluate(key, i, i+1)[0] for key in y}
+
+    else:
+
+        for i in range(len(X)):
+            yield {key: X.evaluate(key, i, i+1)[0] for key in feature_names}, X.evaluate(y[0], i, i+1)[0]
 
 
 class DictReader(csv.DictReader):

--- a/creme/stream.py
+++ b/creme/stream.py
@@ -17,11 +17,6 @@ try:
 except ImportError:
     PANDAS_INSTALLED = False
 from sklearn import utils
-try:
-    from vaex.utils import _ensure_strings_from_expressions, _ensure_list
-    VAEX_INSTALLED = True
-except ImportError:
-    VAEX_INSTALLED = False
 
 __all__ = [
     'iter_csv',
@@ -129,8 +124,7 @@ def iter_vaex(X, y=None, features=None, **kwargs):
         tuple: A pair (``x``, ``y``) where ``x`` is a dict of features and ``y`` is the target.
     """
 
-    if VAEX_INSTALLED is not True:
-        raise ValueError('Please install vaex befor using this convenience function.')
+    from vaex.utils import _ensure_strings_from_expressions, _ensure_list
 
     features = _ensure_strings_from_expressions(features)
     feature_names = features or X.get_column_names()


### PR DESCRIPTION
Hello! 

First of all, great work on this project. It has a lot of potential! I really hope it will continue to grow and improve. 

This is just a small PR which adds a function to iterate over `vaex` DataFrames. 
Here is a minimal working example (screen-shot)
![image](https://user-images.githubusercontent.com/18574951/66217811-42330b80-e6c8-11e9-86d9-1350a775e830.png)

[Vaex](https://github.com/vaexio/vaex) is a DataFrame library (ala) `pandas`, but specialized for working with much larger datasets that do not fit onto the memory of a single computer. In a way, it shares similar concepts to `creme`, i.e. computing statistics in chunks. 

I can see these libraries working well together. I agree that for taking models to production, monitoring etc.. online learning makes a lot of sense, and is something I am considering for my upcoming models. But sometimes one does have plenty of data to experiment and train on, create features etc, before actually building the model and considering production. Synergy between these two libraries may solve both problems: exploration and analysis of "big" data locally, and creating a model and taking it to production, and not really needed to retrain it as time goes on.

