### PR TITLE
AdaboostClassifier

### DIFF
--- a/creme/ensemble/__init__.py
+++ b/creme/ensemble/__init__.py
@@ -1,6 +1,7 @@
 """Ensemble learning."""
 from .bagging import BaggingClassifier
 from .bagging import BaggingRegressor
+from .boosting import AdaboostClassifier
 from .hedging import HedgeRegressor
 from .stacking import StackingBinaryClassifier
 
@@ -9,5 +10,6 @@ __all__ = [
     'BaggingClassifier',
     'BaggingRegressor',
     'HedgeRegressor',
-    'StackingBinaryClassifier'
+    'StackingBinaryClassifier',
+    'AdaboostClassifier'
 ]

--- a/creme/ensemble/__init__.py
+++ b/creme/ensemble/__init__.py
@@ -1,15 +1,15 @@
 """Ensemble learning."""
 from .bagging import BaggingClassifier
 from .bagging import BaggingRegressor
-from .boosting import AdaboostClassifier
+from .boosting import AdaBoostClassifier
 from .hedging import HedgeRegressor
 from .stacking import StackingBinaryClassifier
 
 
 __all__ = [
+    'AdaBoostClassifier',
     'BaggingClassifier',
     'BaggingRegressor',
     'HedgeRegressor',
     'StackingBinaryClassifier',
-    'AdaboostClassifier'
 ]

--- a/creme/ensemble/boosting.py
+++ b/creme/ensemble/boosting.py
@@ -54,7 +54,7 @@ class AdaBoostClassifier(base.Classifier, BaseBoosting):
 
             >>> metric = metrics.LogLoss()
 
-            >>> model = ensemble.AdaboostClassifier(
+            >>> model = ensemble.AdaBoostClassifier(
             ...     model=(
             ...         tree.DecisionTreeClassifier(
             ...             criterion='gini', 
@@ -70,7 +70,7 @@ class AdaBoostClassifier(base.Classifier, BaseBoosting):
             LogLoss: 0.5531 
 
             >>> print(model)
-            AdaboostClassifier(DecisionTreeClassifier)
+            AdaBoostClassifier(DecisionTreeClassifier)
 
     References:
         1. `Online Bagging and Boosting <https://ti.arc.nasa.gov/m/profile/oza/files/ozru01a.pdf>`_

--- a/creme/ensemble/boosting.py
+++ b/creme/ensemble/boosting.py
@@ -74,7 +74,7 @@ class AdaBoostClassifier(base.Classifier, BaseBoosting):
             ... )
 
             >>> model_selection.online_score(X_y, model, metric)
-            LogLoss: 0.5531 
+            LogLoss: 0.5531
 
             >>> print(model)
             AdaBoostClassifier(DecisionTreeClassifier)

--- a/creme/ensemble/boosting.py
+++ b/creme/ensemble/boosting.py
@@ -56,14 +56,18 @@ class AdaboostClassifier(BaseBoosting):
 
             >>> model = ensemble.AdaboostClassifier(
             ...     model=(
-            ...         tree.DecisionTreeClassifier()
+            ...         tree.DecisionTreeClassifier(
+            ...             criterion='gini', 
+            ...             confidence=1e-5, 
+            ...             patience=2000
+            ...         )
             ...     ),
             ...     n_models=5,
             ...     random_state=42
             ... )
 
             >>> model_selection.online_score(X_y, model, metric)
-            LogLoss: 0.5531
+            LogLoss: 0.5531 
 
             >>> print(model)
             AdaboostClassifier(DecisionTreeClassifier)

--- a/creme/ensemble/boosting.py
+++ b/creme/ensemble/boosting.py
@@ -8,7 +8,7 @@ from sklearn import utils
 from .. import base
 
 
-__all__ = ['AdaboostClassifier']
+__all__ = ['AdaBoostClassifier']
 
 
 class BaseBoosting(base.Wrapper, base.Ensemble):
@@ -23,7 +23,7 @@ class BaseBoosting(base.Wrapper, base.Ensemble):
         return self.model
 
 
-class AdaboostClassifier(BaseBoosting):
+class AdaBoostClassifier(base.Classifier, BaseBoosting):
     '''Boosting for classification
 
     For each incoming observation, each model's ``fit_one`` method is called ``k`` times where
@@ -80,7 +80,7 @@ class AdaboostClassifier(BaseBoosting):
 
     def __init__(self, model, n_models=10, random_state=None):
         super().__init__(model, n_models, random_state)
-        self.wrong_weight   = collections.defaultdict(int)
+        self.wrong_weight = collections.defaultdict(int)
         self.correct_weight = collections.defaultdict(int)
 
     def fit_one(self, x, y):  
@@ -113,21 +113,12 @@ class AdaboostClassifier(BaseBoosting):
         predictions   = {}
 
         for i, model in enumerate(self):
-            epsilon  = self.correct_weight[i] + 1e-16
+            epsilon = self.correct_weight[i] + 1e-16
             epsilon /= (self.wrong_weight[i]  + 1e-16)
-            weight   = np.log(epsilon)
+            weight = np.log(epsilon)
             model_weights[i] += weight 
             predictions[i] = model.predict_proba_one(x)
 
         y_pred = predictions[max(model_weights, key=model_weights.get)]
         total = sum(y_pred.values())
         return {label: proba / total for label, proba in y_pred.items()}
-
-
-    def predict_one(self, x):
-        """
-        Store the predictions with the corresponding weights for each weak learner and return the 
-        prediction associated with the maximum weight.
-        """
-        return self.predict_proba_one(x)
-

--- a/creme/ensemble/boosting.py
+++ b/creme/ensemble/boosting.py
@@ -1,7 +1,6 @@
 import collections
 import copy
-
-import numpy as np
+import math
 
 from sklearn import utils
 
@@ -38,12 +37,20 @@ class AdaBoostClassifier(base.Classifier, BaseBoosting):
             ``random_state`` is the random number generator; if ``None``, the random number
             generator is the ``RandomState`` instance used by `numpy.random`.
 
+    Attributes:
+        wrong_weight (collections.defaultdict): Number of times a model has made a mistake
+            when making predictions.
+        correct_weight (collections.defaultdict): Number of times a model has predicted the right
+            label when making predictions.
+
+
     Example:
 
         In the following example three tree classifiers are boosted together. The performance is
         slightly better than when using a single tree.
 
         ::
+
             >>> from creme import datasets
             >>> from creme import ensemble
             >>> from creme import metrics
@@ -74,7 +81,7 @@ class AdaBoostClassifier(base.Classifier, BaseBoosting):
 
     References:
         1. `Online Bagging and Boosting <https://ti.arc.nasa.gov/m/profile/oza/files/ozru01a.pdf>`_
-        2. `https://github.com/crm416/online_boosting/blob/master/ensemblers/adaboost.py`_
+        2. `Github repository for online boosting <https://github.com/crm416/online_boosting/blob/master/ensemblers/adaboost.py>`_
 
     '''
 
@@ -115,7 +122,7 @@ class AdaBoostClassifier(base.Classifier, BaseBoosting):
         for i, model in enumerate(self):
             epsilon = self.correct_weight[i] + 1e-16
             epsilon /= (self.wrong_weight[i]  + 1e-16)
-            weight = np.log(epsilon)
+            weight = math.log(epsilon)
             model_weights[i] += weight 
             predictions[i] = model.predict_proba_one(x)
 

--- a/creme/ensemble/boosting.py
+++ b/creme/ensemble/boosting.py
@@ -1,0 +1,129 @@
+import collections
+import copy
+
+import numpy as np
+
+from sklearn import utils
+
+from .. import base
+
+
+__all__ = ['AdaboostClassifier']
+
+
+class BaseBoosting(base.Wrapper, base.Ensemble):
+
+    def __init__(self, model, n_models=10, random_state=None):
+        super().__init__(copy.deepcopy(model) for i in range(n_models))
+        self.model = model
+        self.rng = utils.check_random_state(random_state)
+
+    @property
+    def _model(self):
+        return self.model
+
+
+class AdaboostClassifier(BaseBoosting):
+    '''Boosting for classification
+
+    For each incoming observation, each model's ``fit_one`` method is called ``k`` times where
+    ``k`` is sampled from a Poisson distribution of parameter lambda. The lambda parameter is 
+    updated when the weaks learners fit successively the same observation. 
+
+    Parameters:
+        model (BinaryClassifier or MultiClassifier): The classifier to boost.
+        n_models (int): The number of models in the ensemble.
+        random_state (int, ``numpy.random.RandomState`` instance or None): If int, ``random_state``
+            is the seed used by the random number generator; if ``RandomState`` instance,
+            ``random_state`` is the random number generator; if ``None``, the random number
+            generator is the ``RandomState`` instance used by `numpy.random`.
+
+    Example:
+
+        In the following example three tree classifiers are bagged together. The performance is
+        slightly better than when using a single tree.
+
+        ::
+            >>> from creme import datasets
+            >>> from creme import ensemble
+            >>> from creme import metrics
+            >>> from creme import model_selection
+            >>> from creme import tree
+
+            >>> X_y = datasets.fetch_electricity()
+
+            >>> metric = metrics.LogLoss()
+
+            >>> model = ensemble.AdaboostClassifier(
+            ...     model=(
+            ...         tree.DecisionTreeClassifier()
+            ...     ),
+            ...     n_models=5,
+            ...     random_state=42
+            ... )
+
+            >>> model_selection.online_score(X_y, model, metric)
+            LogLoss: 0.5531
+
+            >>> print(model)
+            AdaboostClassifier(DecisionTreeClassifier)
+
+    References:
+        1. `Online Bagging and Boosting <https://ti.arc.nasa.gov/m/profile/oza/files/ozru01a.pdf>`_
+        2. https://github.com/crm416/online_boosting/blob/master/ensemblers/adaboost.py
+
+    '''
+
+    def __init__(self, model, n_models=10, random_state=None):
+        super().__init__(model, n_models, random_state)
+        self.wrong_weight   = collections.defaultdict(int)
+        self.correct_weight = collections.defaultdict(int)
+
+    def fit_one(self, x, y):  
+        lambda_poisson = 1
+        
+        for i, model in enumerate(self):
+            for _ in range(self.rng.poisson(lambda_poisson)):
+                model.fit_one(x, y)
+            
+            if model.predict_one(x) == y:
+                self.correct_weight[i] += lambda_poisson
+                lambda_poisson *= (
+                    (self.correct_weight[i] + self.wrong_weight[i]) / (2 * self.correct_weight[i]) 
+                )
+            
+            else:
+                self.wrong_weight[i] += lambda_poisson
+                lambda_poisson *= (
+                    (self.correct_weight[i] + self.wrong_weight[i]) / (2 * self.wrong_weight[i])
+                )
+        return self
+
+
+    def predict_proba_one(self, x):
+        """
+        Store the predicted probabilities with the corresponding weights for each weak learner and 
+        return the probabilities associated to the model which has maximum weight.
+        """
+        model_weights = collections.defaultdict(int)
+        predictions   = {}
+
+        for i, model in enumerate(self):
+            epsilon  = self.correct_weight[i] + 1e-16
+            epsilon /= (self.wrong_weight[i]  + 1e-16)
+            weight   = np.log(epsilon)
+            model_weights[i] += weight 
+            predictions[i] = model.predict_proba_one(x)
+
+        y_pred = predictions[max(model_weights, key=model_weights.get)]
+        total = sum(y_pred.values())
+        return {label: proba / total for label, proba in y_pred.items()}
+
+
+    def predict_one(self, x):
+        """
+        Store the predictions with the corresponding weights for each weak learner and return the 
+        prediction associated with the maximum weight.
+        """
+        return self.predict_proba_one(x)
+

--- a/creme/ensemble/boosting.py
+++ b/creme/ensemble/boosting.py
@@ -40,7 +40,7 @@ class AdaboostClassifier(BaseBoosting):
 
     Example:
 
-        In the following example three tree classifiers are bagged together. The performance is
+        In the following example three tree classifiers are boosted together. The performance is
         slightly better than when using a single tree.
 
         ::
@@ -74,7 +74,7 @@ class AdaboostClassifier(BaseBoosting):
 
     References:
         1. `Online Bagging and Boosting <https://ti.arc.nasa.gov/m/profile/oza/files/ozru01a.pdf>`_
-        2. https://github.com/crm416/online_boosting/blob/master/ensemblers/adaboost.py
+        2. `https://github.com/crm416/online_boosting/blob/master/ensemblers/adaboost.py`_
 
     '''
 

--- a/creme/test_.py
+++ b/creme/test_.py
@@ -76,6 +76,9 @@ def get_all_estimators():
             elif issubclass(obj, ensemble.BaggingRegressor):
                 inst = obj(linear_model.LinearRegression())
 
+            elif issubclass(obj, ensemble.AdaBoostClassifier):
+                inst = obj(linear_model.LogisticRegression())
+
             elif issubclass(obj, ensemble.HedgeRegressor):
                 inst = obj([
                     preprocessing.StandardScaler() | linear_model.LinearRegression(intercept_lr=0.1),

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -172,7 +172,7 @@ This module contains wrappers for making ``creme`` estimators compatible with ot
     :nosignatures:
     :template: class.rst
 
-    AdaboostClassifier    
+    AdaBoostClassifier   
     BaggingClassifier
     BaggingRegressor
     HedgeRegressor

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -171,7 +171,8 @@ This module contains wrappers for making ``creme`` estimators compatible with ot
     :toctree: generated/
     :nosignatures:
     :template: class.rst
-        
+
+    AdaboostClassifier    
     BaggingClassifier
     BaggingRegressor
     HedgeRegressor


### PR DESCRIPTION
Hi, 

Here is AdaboostClassifier. 🤙

The results are interesting. On trees I got better results than a simple decision tree but not as good as a Random Forest. However, Adaboost can be used to make Boosted  Random Forest and the results are better than a single random Forest (very long execution time because the calculations are sequential).

I made a draft pull request because I didn't implement the predict_one method correctly.
The "online_score" method of the "model_selection" class calls by default predict_one for AdaboostClassifier while on BaggingClassifier it calls by default predict_proba_one. I missed something here, I think...

```python
model_selection.online_score(X_y, model, metric) # Call predict_one by default for AdaboostClassifier even if metric is LogLoss
``` 

First boosting model of a long series 🤖

References:
1. [Online Bagging and Boosting](https://ti.arc.nasa.gov/m/profile/oza/files/ozru01a.pdf)
2. [Code](https://github.com/crm416/online_boosting/blob/master/ensemblers/adaboost.py)

Raphaël



