### PR TITLE
minor AdaBound fix

### DIFF
--- a/creme/optim/ada_bound.py
+++ b/creme/optim/ada_bound.py
@@ -49,7 +49,11 @@ class AdaBound(base.Optimizer):
 
         if not isinstance(lr, numbers.Number):
             raise ValueError(
-                f'Learning rate in AdaBound should be numeric but got {type(lr)}')
+                f'lr in AdaBound should be numeric but got {type(lr)}')
+
+        if not isinstance(final_lr, numbers.Number):
+            raise ValueError(
+                f'final_lr in AdaBound should be numeric but got {type(final_lr)}')
 
         super().__init__(lr)
         self.base_lr = lr

--- a/creme/optim/ada_bound.py
+++ b/creme/optim/ada_bound.py
@@ -1,5 +1,6 @@
-import collections
 import math
+import numbers
+import collections
 
 from .. import utils
 
@@ -45,6 +46,11 @@ class AdaBound(base.Optimizer):
     """
 
     def __init__(self, lr=1e-3, beta_1=0.9, beta_2=0.999, eps=1e-8, gamma=1e-3, final_lr=0.1):
+
+        if not isinstance(lr, numbers.Number):
+            raise ValueError(
+                f'Learning rate in AdaBound should be numeric but got {type(lr)}')
+
         super().__init__(lr)
         self.base_lr = lr
         self.final_lr = final_lr


### PR DESCRIPTION
I was trying various optimizers in loop and accidentally run AdaBound with `schedulers` and got `TypeError: unsupported operand type(s) for /: 'float' and 'InverseScaling'` at line 70.

Because `AdaBound` is implicitly changing `lr` and don't require `scheduler`. So it is better to raise an error if in case user uses non-numeric `lr` because the default error is non-informatic.