### PR TITLE
CI: Lint for undefined names in Python code

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -28,10 +28,10 @@ conda create --yes --name testenv python=$PYTHON_VERSION
 source activate testenv
 
 # Install dependencies required for testing
-pip install cython
+pip install codecov cython flake8
 pip install -e ".[dev]"
-pip install codecov
 
 # Run tests and coverage
+flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 pytest --cov=creme -m "not web"
 codecov


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/creme-ml/creme on Python 3.8.0

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./creme/reco/baseline.py:80:65: F821 undefined name 'u_optimizer'
        self.loss = optim.losses.Squared() if loss is None else u_optimizer
                                                                ^
1     F821 undefined name 'u_optimizer'
1
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

Also, pip will soon have a real dependancy resolver so it is better to give it more requirements in a single command so that it can a more complete job of resolving the dependancies.

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.