### PR TITLE
Hotfix - Error with DecisionTreeClassifier.draw() #272

### DIFF
--- a/creme/tree/base.py
+++ b/creme/tree/base.py
@@ -140,7 +140,7 @@ class Leaf(Node):
     def height(self):
         return 0
 
-    def iter_dfs(self, depth):
+    def iter_dfs(self, depth = 0):
         yield self, depth
 
     def iter_edges(self):

--- a/creme/tree/base.py
+++ b/creme/tree/base.py
@@ -140,7 +140,7 @@ class Leaf(Node):
     def height(self):
         return 0
 
-    def iter_dfs(self, depth = 0):
+    def iter_dfs(self, depth=0):
         yield self, depth
 
     def iter_edges(self):


### PR DESCRIPTION
@MaxHalford Setting the default value of the depth parameter of the iter_dfs method from class Leaf solve the error. Is there any side effect? 

```
from creme import datasets
from creme import tree


model = tree.DecisionTreeClassifier(
    confidence=1e-50,
)

for x, y in datasets.Phishing():
    model.fit_one(x, y)
    
model.draw(2)
```

<img width="250" alt="image" src="https://user-images.githubusercontent.com/24591024/77348478-d017b700-6d39-11ea-97bf-2c5714e59026.png">
