### PR TITLE
Shift statistic with StatChain feature

### DIFF
--- a/creme/compose/__init__.py
+++ b/creme/compose/__init__.py
@@ -4,19 +4,23 @@ This module contains utilities for merging multiple modeling steps into a single
 pipelines are not the only way to process a stream of data, we highly encourage you to use them.
 
 """
+from .func import FuncStat
 from .func import FuncTransformer
 from .pipeline import Pipeline
 from .rename import Renamer
 from .union import TransformerUnion
 from .select import Discard
 from .select import Select
+from .stat_chain import StatChain
 
 
 __all__ = [
     'Discard',
+    'FuncStat',
     'FuncTransformer',
     'Pipeline',
     'Renamer',
     'TransformerUnion',
-    'Select'
+    'Select',
+    'StatChain',
 ]

--- a/creme/compose/func.py
+++ b/creme/compose/func.py
@@ -1,9 +1,10 @@
 import typing
 
 from creme import base
+from creme import stats
 
 
-__all__ = ['FuncTransformer']
+__all__ = ['FuncTransformer', 'FuncStat']
 
 
 class FuncTransformer(base.Transformer):
@@ -37,6 +38,42 @@ class FuncTransformer(base.Transformer):
         self.func = func
 
     def transform_one(self, x):
+        return self.func(x)
+
+    def __str__(self):
+        return self.func.__name__
+
+
+class FuncStat(stats.base.Statistic):
+    """Transforms a set of features following a given callable.
+
+    The provided function has to take as input a `dict` of features and produce a new `dict` of
+    transformed features.
+
+    Parameters:
+        func: A function transforming a dict of features into a new dict of features.
+
+    Example:
+
+        >>> import datetime as dt
+        >>> from creme import compose
+
+        >>> x = '2019-02-14'
+
+        >>> def parse_date(x):
+        ...     x = dt.datetime.strptime(x, '%Y-%m-%d')
+        ...     return x.day
+
+        >>> stat = compose.FuncStat(parse_date)
+        >>> stat.update(x)
+        14
+
+    """
+
+    def __init__(self, func: typing.Callable[[dict], dict]):
+        self.func = func
+
+    def update(self, x):
         return self.func(x)
 
     def __str__(self):

--- a/creme/compose/pipeline.py
+++ b/creme/compose/pipeline.py
@@ -235,7 +235,7 @@ class Pipeline(base.Estimator):
             if t.is_supervised:
 
                 if isinstance(t, union.TransformerUnion):
-                    for sub_t in t.values():
+                    for sub_t in t.transformers.values():
                         if sub_t.is_supervised:
                             sub_t.fit_one(x=x_pre, y=y)
 

--- a/creme/compose/stat_chain.py
+++ b/creme/compose/stat_chain.py
@@ -1,0 +1,146 @@
+
+import collections
+import types
+import typing
+
+from creme import stats
+
+from . import func
+from . import union
+
+
+__all__ = ['StatChain']
+
+
+class StatChain:
+    """Chains a sequence of statistics.
+
+    Sequentially apply a list of statistics.
+
+    Parameters:
+        statistics: Ideally a list of (name, statistic) tuples. If a statistic is given without a name,
+            then a name is automatically inferred from the statistics.
+
+    Attributes:
+        statistics (collections.OrderedDict)
+
+        >>> from pprint import pprint
+        >>> import creme.compose
+        >>> import creme.feature_extraction
+        >>> import creme.stats
+
+        >>> X = [
+        ...     1,
+        ...     2,
+        ...     3,
+        ...     4,
+        ...     5,
+        ...     6,
+        ... ]
+
+        >>> statistics = creme.stats.Shift(2) | creme.stats.RollingMean(2)
+
+        >>> statistics
+        Shift: 0.
+        RollingMean: 0.
+
+        >>> for x in X:
+        ...     pprint(statistics.update(x).get())
+            0.0
+            0.0
+            0.5
+            1.5
+            2.5
+            3.5
+
+        >>> print(statistics.name)
+        shift_2_rolling_rollingmean_2
+
+    """
+
+    def __init__(self, *statistics):
+        self.statistics = collections.OrderedDict()
+        for stat in statistics:
+            self |= stat
+
+    def __getitem__(self, key):
+        """Just for convenience."""
+        return self.statistics[key]
+
+    def __len__(self):
+        """Just for convenience."""
+        return len(self.statistics)
+
+    def __str__(self):
+        return ' + '.join(map(str, self.statistics.values()))
+
+    @property
+    def name(self):
+        return '_'.join(self.statistics.keys())
+
+    def __repr__(self):
+        return (''.join('\n'.join(map(repr, self.statistics.values())).splitlines(True))
+            ).expandtabs(2)
+
+    def _get_params(self):
+        return dict(self.items())
+
+    def _set_params(self, new_params=None):
+        if new_params is None:
+            new_params = {}
+        return StatChain(*[
+            (name, new_params[name])
+            if isinstance(new_params.get(name), stats.Univariate) else
+            (name, step._set_params(new_params.get(name, {})))
+            for name, step in self.statistics.items()
+        ])
+
+
+    def _add_step(self, stat):
+        """Adds a stat while taking care of the input type."""
+
+        name = None
+        if isinstance(stat, tuple):
+            name, stat = stat
+
+        # If the step is a function then wrap it in a FuncTransformer
+        if isinstance(stat, (types.FunctionType, types.LambdaType)):
+            stat = func.FuncStat(stat)
+
+        def infer_name(stat):
+            if isinstance(stat, func.FuncStat):
+                return infer_name(stat.func)
+            elif isinstance(stat, stats.base.Statistic):
+                return stat.name
+            elif hasattr(stat, '__class__'):
+                return stat.__class__.__name__
+            return str(stat)
+
+        # Infer a name if none is given
+        if name is None:
+            name = infer_name(stat)
+
+        if name in self.statistics:
+            counter = 1
+            while f'{name}{counter}' in self.statistics:
+                counter += 1
+            name = f'{name}{counter}'
+
+        # Store the stat
+        self.statistics[name] = stat
+
+        return self
+
+    def __or__(self, other):
+        """Inserts a step at the end of the chain."""
+        self._add_step(other)
+        return self
+
+    def update(self, x):
+        for stat in self.statistics.values():
+            x = stat.update(x).get()
+        return self
+
+    def get(self):
+        """Get the value of the last statistic of the ChainStat"""
+        return self.statistics[next(reversed(self.statistics))].get()

--- a/creme/compose/stat_chain.py
+++ b/creme/compose/stat_chain.py
@@ -18,15 +18,13 @@ class StatChain:
     Sequentially apply a list of statistics.
 
     Parameters:
-        statistics: Ideally a list of (name, statistic) tuples. If a statistic is given without a name,
-            then a name is automatically inferred from the statistics.
+        statistics: Ideally a list of (name, statistic) tuples. If a statistic is given without a
+            name, then a name is automatically inferred from the statistics.
 
     Attributes:
         statistics (collections.OrderedDict)
 
         >>> from pprint import pprint
-        >>> import creme.compose
-        >>> import creme.feature_extraction
         >>> import creme.stats
 
         >>> X = [

--- a/creme/compose/stat_chain.py
+++ b/creme/compose/stat_chain.py
@@ -41,8 +41,8 @@ class StatChain:
         >>> statistics = creme.stats.Shift(2) | creme.stats.RollingMean(2)
 
         >>> statistics
-        Shift: 0.
-        RollingMean: 0.
+        Shift: 0.,
+            RollingMean: 0.
 
         >>> for x in X:
         ...     pprint(statistics.update(x).get())
@@ -79,8 +79,8 @@ class StatChain:
         return '_'.join(self.statistics.keys())
 
     def __repr__(self):
-        return (''.join('\n'.join(map(repr, self.statistics.values())).splitlines(True))
-            ).expandtabs(2)
+        return ('\t'.join(',\n'.join(map(repr, self.statistics.values())).splitlines(True))
+        ).expandtabs(2)
 
     def _get_params(self):
         return dict(self.items())

--- a/creme/stats/__init__.py
+++ b/creme/stats/__init__.py
@@ -29,6 +29,7 @@ from .quantile import Quantile
 from .quantile import RollingQuantile
 from .sem import SEM
 from .sem import RollingSEM
+from .shift import Shift
 from .skew import Skew
 from .summing import Sum
 from .summing import RollingSum
@@ -68,6 +69,7 @@ __all__ = [
     'RollingSum',
     'RollingVar',
     'SEM',
+    'Shift',
     'Skew',
     'Sum',
     'Univariate',

--- a/creme/stats/base.pyx
+++ b/creme/stats/base.pyx
@@ -14,6 +14,20 @@ cdef class Statistic:
     def __repr__(self):
         return f'{self.__class__.__name__}: {self.get():{self._fmt}}'.rstrip('0')
 
+    def __or__(self, other):
+        """Merges with another statistic into a StatChain."""
+        from .. import compose
+        if isinstance(other, compose.StatChain):
+            return other.__ror__(self)
+        return compose.StatChain(self, other)
+
+    def __ror__(self, other):
+        """Merges with another statistic into a StatChain."""
+        from .. import compose
+        if isinstance(other, compose.StatChain):
+            return other.__or__(self)
+        return compose.StatChain(other, self)
+
 
 cdef class Univariate(Statistic):
     """A univariate statistic measures a property of a variable."""

--- a/creme/stats/shift.py
+++ b/creme/stats/shift.py
@@ -84,6 +84,7 @@ class Shift(base.Univariate):
             {'target_shift_1_mean_by_place': 33.5}
 
     """
+
     def __init__(self, period: int, missing: float=0., fit_before_transform: bool=True):
         self.period = period
         self.missing = missing

--- a/creme/stats/shift.py
+++ b/creme/stats/shift.py
@@ -1,0 +1,107 @@
+import collections
+import typing
+
+from . import base
+
+__all__ = ['Shift']
+
+
+class Shift(base.Univariate):
+    """Shift the observations with the selected period.
+
+    Shift class allows to store and recall at regular intervals values observed in a stream.
+    The method `get()` returns the n-th - period observed entry.
+
+    Parameters:
+        period: Number of periods to shift. Must be positive.
+        missing: Handle missing values when there is'nt any reference for a given period.
+        fit_before_transform: Shift logic. Must be set to True when the user updates the
+            buffer before retrieving the observation with the offset selected.
+
+    Example:
+
+        ::
+
+            >>> import creme
+
+            >>> shift = creme.stats.Shift(period=2, missing=-1)
+
+            >>> X = [
+            ...    1,
+            ...    2,
+            ...    3,
+            ...    4,
+            ...    5,
+            ... ]
+
+            >>> for x in X:
+            ...    print(shift.update(x).get())
+            -1
+            -1
+            1
+            2
+            3
+
+            It is possible to compute shifted statistics with operator |.
+
+            >>> statistics = creme.stats.Shift(2) | creme.stats.RollingMean(1)
+            >>> for x in X:
+            ...    print(statistics.update(x).get())
+            0.0
+            0.0
+            1.0
+            2.0
+            3.0
+
+            You can include Shift into a pipeline such as:
+
+            >>> X_y = [
+            ...    ({'store_id': 'darty', 'open': 1}, 1.),
+            ...    ({'store_id': 'fnac', 'open': 0}, 2.),
+            ...    ({'store_id': 'darty', 'open': 3}, 3.),
+            ...    ({'store_id': 'darty', 'open': 1}, 4.),
+            ...    ({'store_id': 'ikea', 'open': 1}, 5.),
+            ...    ({'store_id': 'ikea', 'open': 1}, 10.),
+            ... ]
+
+            >>> pipeline = creme.feature_extraction.Agg(
+            ...         by=['store_id'],
+            ...         on='open',
+            ...         how=creme.stats.Shift(1) | creme.stats.Sum()
+            ...     ) + creme.feature_extraction.TargetAgg(
+            ...             by=['store_id'],
+            ...             how=creme.stats.Shift(1) | creme.stats.RollingMean(1)
+            ... )
+
+            >>> for x, y in X_y:
+            ...  print(pipeline.fit_one(x, y).transform_one(x))
+            {'target_shift_1_rolling_rollingmean_1_by_store_id': 0.0, 'open_shift_1_sum_by_store_id': 0.0}
+            {'target_shift_1_rolling_rollingmean_1_by_store_id': 0.0, 'open_shift_1_sum_by_store_id': 0.0}
+            {'target_shift_1_rolling_rollingmean_1_by_store_id': 1.0, 'open_shift_1_sum_by_store_id': 1.0}
+            {'target_shift_1_rolling_rollingmean_1_by_store_id': 3.0, 'open_shift_1_sum_by_store_id': 4.0}
+            {'target_shift_1_rolling_rollingmean_1_by_store_id': 0.0, 'open_shift_1_sum_by_store_id': 0.0}
+            {'target_shift_1_rolling_rollingmean_1_by_store_id': 5.0, 'open_shift_1_sum_by_store_id': 1.0}
+
+    """
+    def __init__(self, period: int, missing: float=0., fit_before_transform: bool=True):
+        self.period = period
+        self.missing = missing
+        self.period_logic = period
+
+        if fit_before_transform:
+            self.period += 1
+
+        self.buffer = collections.deque(maxlen=self.period)
+
+    @property
+    def name(self):
+        return f'shift_{self.period_logic}'
+
+    def update(self, x):
+        self.buffer.append(x)
+        return self
+
+    def get(self):
+        if len(self.buffer) == self.period:
+            return self.buffer[0]
+        return self.missing

--- a/creme/stats/shift.py
+++ b/creme/stats/shift.py
@@ -64,14 +64,10 @@ class Shift(base.Univariate):
             ...    ({'store_id': 'ikea', 'open': 1}, 10.),
             ... ]
 
-            >>> pipeline = creme.feature_extraction.Agg(
-            ...         by=['store_id'],
-            ...         on='open',
-            ...         how=creme.stats.Shift(1) | creme.stats.Sum()
-            ...     ) + creme.feature_extraction.TargetAgg(
-            ...             by=['store_id'],
-            ...             how=creme.stats.Shift(1) | creme.stats.RollingMean(1)
-            ... )
+            >>> pipeline = creme.feature_extraction.Agg(by=['store_id'], on='open',
+            ...     how=creme.stats.Shift(1) | creme.stats.Sum()
+            ... ) + creme.feature_extraction.TargetAgg(by=['store_id'],
+            ...     how=creme.stats.Shift(1) | creme.stats.RollingMean(1))
 
             >>> for x, y in X_y:
             ...  print(pipeline.fit_one(x, y).transform_one(x))
@@ -87,10 +83,8 @@ class Shift(base.Univariate):
         self.period = period
         self.missing = missing
         self.period_logic = period
-
         if fit_before_transform:
             self.period += 1
-
         self.buffer = collections.deque(maxlen=self.period)
 
     @property


### PR DESCRIPTION
```python
>>> import creme

>>> shift = creme.stats.Shift(period=2, missing=-1)

>>> X = [
...    1,
...    2,
...    3,
...    4,
...    5,
... ]

>>> for x in X:
...    print(shift.update(x).get())
-1
-1
1
2
3

It is possible to compute shifted statistics with operator |.

>>> statistics = creme.stats.Shift(2) | creme.stats.RollingMean(1)
>>> for x in X:
...    print(statistics.update(x).get())
0.0
0.0
1.0
2.0
3.0
```
    You can include Shift into a pipeline such as:

```python

    >>> X_y = [
    ...    ({'store_id': 'darty', 'open': 1}, 1.),
    ...    ({'store_id': 'fnac', 'open': 0}, 2.),
    ...    ({'store_id': 'darty', 'open': 3}, 3.),
    ...    ({'store_id': 'darty', 'open': 1}, 4.),
    ...    ({'store_id': 'ikea', 'open': 1}, 5.),
    ...    ({'store_id': 'ikea', 'open': 1}, 10.),
    ... ]

    >>> pipeline = creme.feature_extraction.Agg(by=['store_id'], on='open',
    ...     how=creme.stats.Shift(1) | creme.stats.Sum()
    ... ) + creme.feature_extraction.TargetAgg(by=['store_id'],
    ...     how=creme.stats.Shift(1) | creme.stats.RollingMean(1))

    >>> for x, y in X_y:
    ...  print(pipeline.fit_one(x, y).transform_one(x))
    {'target_shift_1_rolling_rollingmean_1_by_store_id': 0.0, 'open_shift_1_sum_by_store_id': 0.0}
    {'target_shift_1_rolling_rollingmean_1_by_store_id': 0.0, 'open_shift_1_sum_by_store_id': 0.0}
    {'target_shift_1_rolling_rollingmean_1_by_store_id': 1.0, 'open_shift_1_sum_by_store_id': 1.0}
    {'target_shift_1_rolling_rollingmean_1_by_store_id': 3.0, 'open_shift_1_sum_by_store_id': 4.0}
    {'target_shift_1_rolling_rollingmean_1_by_store_id': 0.0, 'open_shift_1_sum_by_store_id': 0.0}
    {'target_shift_1_rolling_rollingmean_1_by_store_id': 5.0, 'open_shift_1_sum_by_store_id': 1.0}

```