### PR TITLE
WIP Cython dict wrapper supporting vector-like operations

### DIFF
--- a/creme/utils/__init__.py
+++ b/creme/utils/__init__.py
@@ -5,6 +5,7 @@ from . import pretty
 from .histogram import Histogram
 from .sdft import SDFT
 from .skyline import Skyline
+from .vectordict import VectorDict
 from .window import Window
 from .window import SortedWindow
 
@@ -15,5 +16,6 @@ __all__ = [
     'SDFT',
     'Skyline',
     'SortedWindow',
+    'VectorDict',
     'Window'
 ]

--- a/creme/utils/vectordict.pyx
+++ b/creme/utils/vectordict.pyx
@@ -1,0 +1,256 @@
+cimport cython
+
+cdef VectorDict _add_const(VectorDict res, other):
+    # add the constant other to res then return res
+    for key, value in res._map.items():
+        res._map[key] = value + other
+    return res
+
+cdef VectorDict _add_dict(VectorDict res, dict other):
+    # add the dict other to res then return res
+    for key, value in other.items():
+        res._map[key] = res._map.get(key, 0) + value
+    return res
+
+cdef VectorDict _sub_const(VectorDict res, other, int rev):
+    # subtract the constant other to res then return res
+    if rev:
+        for key, value in res._map.items():
+            res._map[key] = other - value
+    else:
+        for key, value in res._map.items():
+            res._map[key] = value - other
+    return res
+
+cdef VectorDict _sub_dict(VectorDict res, dict other, int rev):
+    # subtract the dict other to res then return res
+    if rev:
+        for key, value in other.items():
+            res._map[key] = value - res._map.get(key, 0)
+    else:
+        for key, value in other.items():
+            res._map[key] = res._map.get(key, 0) - value
+    return res
+
+
+cdef VectorDict _mul_const(VectorDict res, other):
+    # multiply all values in res by other and return res
+    for key, value in res._map.items():
+        res._map[key] = other * value
+    return res
+
+
+cdef VectorDict _div_const(VectorDict res, other):
+    # divide all values in res by other and return res
+    for key, value in res._map.items():
+        res._map[key] = value / other
+    return res
+
+
+cdef _dot_dicts(dict x, dict y):
+    # return the dot product of the dictionaries x and y
+    if len(x) < len(y):
+        x, y = y, x
+    res = 0
+    for i, xi in x.items():
+        res += xi * y.get(i, 0)
+    return res
+
+
+cdef class VectorDict:
+    cdef dict _map
+
+    def __init__(self, other=None):
+        """A dictionary-like object that supports vector-like operations.
+
+        Supports addition and subtraction with a VectorDict, a dict or a constant.
+        Supports multiplication and division by a constant.
+        Supports dot product with a VectorDict or dict through the @ operator.
+
+        Parameters:
+            other: a VectorDict or dict to copy key-values from, or None
+        """
+        if other is None:
+            pass
+        elif isinstance(other, dict):
+            self._map = dict(other)
+        elif isinstance(other, VectorDict):
+            other_ = <VectorDict> other
+            self._map = dict(other_._map)
+        else:
+            raise ValueError("Unsupported type: {}".format(type(other)))
+
+    # pass-through methods to the underlying dict
+
+    def __contains__(self, key):
+        return self._map.__contains__(key)
+
+    def __delitem__(self, key):
+        self._map.__delitem__(key)
+
+    def __eq__(self, other):
+        return self._map.__eq__(other)
+
+    def __format__(self, format_spec):
+        return self._map.__format__(format_spec)
+
+    def __getitem__(self, key):
+        return self._map[key]
+
+    def __iter__(self):
+        return self._map.__iter__()
+
+    def __len__(self):
+        return self._map.__len__()
+
+    def __repr__(self):
+        return self._map.__repr__()
+
+    def __setitem__(self, key, value):
+        self._map[key] = value
+
+    def __str__(self):
+        return self._map.__str__()
+
+    def clear(self):
+        return self._map.clear()
+
+    def items(self):
+        return self._map.items()
+
+    def keys(self):
+        return self._map.keys()
+
+    def pop(self, *args, **kwargs):
+        return self._map.pop(*args, **kwargs)
+
+    def popitem(self):
+        return self._map.popitem()
+
+    def setdefault(self, *args, **kwargs):
+        return self._map.setdefault(*args, **kwargs)
+
+    def update(self, *args, **kwargs):
+        return self._map.update(*args, **kwargs)
+
+    def values(self):
+        return self._map.values()
+
+    # export methods
+
+    def copy(self):
+        return VectorDict(self._map)
+
+    def todict(self):
+        return self._map.copy()
+
+    # operator methods
+
+    def __add__(left, right):
+        if isinstance(left, VectorDict):
+            if isinstance(right, dict):
+                return _add_dict(VectorDict(left), right)
+            if isinstance(right, VectorDict):
+                right_ = <VectorDict> right
+                return _add_dict(VectorDict(left), right_._map)
+            try:
+                return _add_const(VectorDict(left), right)
+            except TypeError:
+                return NotImplemented
+        if isinstance(left, dict):
+            return _add_dict(VectorDict(right), left)
+        try:
+            return _add_const(VectorDict(right), left)
+        except TypeError:
+            return NotImplemented
+
+    def __iadd__(self, other):
+        if isinstance(other, dict):
+            return _add_dict(self, other)
+        if isinstance(other, VectorDict):
+            other_ = <VectorDict> other
+            return _add_dict(self, other_._map)
+        try:
+            return _add_const(self, other)
+        except TypeError:
+            return NotImplemented
+
+    def __sub__(left, right):
+        if isinstance(left, VectorDict):
+            if isinstance(right, dict):
+                return _sub_dict(VectorDict(left), right, False)
+            if isinstance(right, VectorDict):
+                right_ = <VectorDict> right
+                return _sub_dict(VectorDict(left), right_._map, False)
+            try:
+                return _sub_const(VectorDict(left), right, False)
+            except TypeError:
+                return NotImplemented
+        if isinstance(left, dict):
+            return _sub_dict(VectorDict(right), left, True)
+        try:
+            return _sub_const(VectorDict(right), left, True)
+        except TypeError:
+            return NotImplemented
+
+    def __isub__(self, other):
+        if isinstance(other, dict):
+            return _sub_dict(self, other, False)
+        if isinstance(other, VectorDict):
+            other_ = <VectorDict> other
+            return _sub_dict(self, other_._map, False)
+        try:
+            return _sub_const(self, other, True)
+        except TypeError:
+            return NotImplemented
+
+    def __mul__(left, right):
+        try:
+            if isinstance(left, VectorDict):
+                return _mul_const(VectorDict(left), right)
+            return _mul_const(VectorDict(right), left)
+        except TypeError:
+            return NotImplemented
+
+    def __imul__(self, other):
+        try:
+            return _mul_const(self, other)
+        except TypeError:
+            return NotImplemented
+
+    def __truediv__(left, right):
+        try:
+            if isinstance(left, VectorDict):
+                return _div_const(VectorDict(left), right)
+        except TypeError:
+            pass
+        return NotImplemented
+
+    def __itruediv__(self, other):
+        try:
+            return _div_const(self, other)
+        except TypeError:
+            return NotImplemented
+
+    def __matmul__(left, right):
+        if isinstance(left, VectorDict):
+            left_ = <VectorDict> left
+            if isinstance(right, dict):
+                return _dot_dicts(left_._map, right)
+            if isinstance(right, VectorDict):
+                right_ = <VectorDict> right
+                return _dot_dicts(left_._map, right_._map)
+            return NotImplemented
+        if isinstance(left, dict):
+            right_ = <VectorDict> right
+            return _dot_dicts(right_._map, left)
+        return NotImplemented
+
+    def __neg__(self):
+        res = VectorDict(self)
+        for key, value in res._map.items():
+            res._map[key] = -value
+        return res
+
+    def __pos__(self):
+        return VectorDict(self)


### PR DESCRIPTION
For #280.
Still WIP, implements a Cython `dict` wrapper that supports vector-like (as in element of a vector space) operations `+`, `-`, `*`, `/` and `@`. Should be useful in `glm` to store the weights, as a lot of dot products and arithmetic between weights and samples are made. Still need to add tests and integrate in code but maybe you can check if it fits the feature request.

Example of speedup and code readability improvement:
```python
>>> from creme.utils.math import dot
>>> x = {'a': 4, 'b': 2, 'c': 5}
>>> y = {'a': 3, 'b': 9, 'd': 4}
>>> %timeit dot(x, y)
993 ns ± 5.01 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

>>> from creme.utils import VectorDict
>>> vx = VectorDict(x)
>>> vy = VectorDict(y)
>>> assert vx @ vy == dot(x, y)
>>> %timeit vx @ vy
>>> %timeit vx @ y  # compatible with raw dict as well, same speed
151 ns ± 2.55 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
154 ns ± 1.8 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
```
Note that I started with a C++ `unordered_map` for speed, similar to scikit-learn's one but although it is faster for operations between Cython objects, operations between Cython objects and `dict` (such as `vx @ y` above) are slow. This is because `dict` keys will be typically `str` which need to be encoded into `bytes` to match / store keys in the C++ map as `string`, incurring overhead. Also it restricts keys to strings while the current implementation allows any Python object as key, making it seamless. As the external API of `creme` is based on `dict`, the proposed design seems better. scikit-learn's `IntFloatDict` with a C++ map is a better choice for them as they keep it internal and don't worry about string encoding.

Also note that there is a similar [implementation](https://pypi.org/project/VectorDict/) but it's in Python so too slow.