### PR TITLE
Add data conversion utilities

### DIFF
--- a/creme/utils/__init__.py
+++ b/creme/utils/__init__.py
@@ -10,13 +10,18 @@ from .skyline import Skyline
 from .vectordict import VectorDict
 from .window import Window
 from .window import SortedWindow
+# Data convertion utilities: to be removed in the future
+from .data_conversion import dict2numpy
+from .data_conversion import numpy2dict
 
 
 __all__ = [
-    'check_estimator'
+    'check_estimator',
+    'dict2numpy',
     'expand_param_grid',
     'inspect',
     'Histogram',
+    'numpy2dict',
     'SDFT',
     'Skyline',
     'SortedWindow',

--- a/creme/utils/data_conversion.py
+++ b/creme/utils/data_conversion.py
@@ -1,0 +1,53 @@
+import numpy as np
+
+
+def dict2numpy(data):
+    """Convert a dictionary containing data to a numpy.array
+
+    Parameters
+    ----------
+    data : dict
+        A dictionary whose keys represent input attributes and the values
+        represent their observed contents.
+
+    Returns
+    -------
+        numpy.array
+            An array representation of the values in `data`.
+
+    Examples
+    --------
+    >>> from creme.utils import dict2numpy
+    >>> dict2numpy({'a': 1, 'b': 2, 3: 3})
+    array([1, 2, 3])
+
+    Notes
+    -----
+        There is not restriction to the type of keys in `data`, but values
+        must be strictly numeric.
+    """
+    return np.asarray(list(data.values()))
+
+
+def numpy2dict(data):
+    """Convert a numpy array to a dictionary.
+
+    Parameters
+    ----------
+    data : numpy.array
+        An one-dimensional numpy.array.
+
+    Returns
+    -------
+        dict
+            A dictionary where keys are integers :math: `k \in \{0, 1, ..., |\mathtt{data}| - 1\}`,
+            and the values are each one of the :math: `k` entries in `data`.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from creme.utils import numpy2dict
+    >>> numpy2dict(np.array([1.0, 2.0, 3.0]))
+    {0: 1.0, 1: 2.0, 2: 3.0}
+    """
+    return {k: v for k, v in enumerate(data)}

--- a/creme/utils/data_conversion.py
+++ b/creme/utils/data_conversion.py
@@ -40,8 +40,8 @@ def numpy2dict(data):
     Returns
     -------
         dict
-            A dictionary where keys are integers :math: `k \in \{0, 1, ..., |\mathtt{data}| - 1\}`,
-            and the values are each one of the :math: `k` entries in `data`.
+            A dictionary where keys are integers $k \in \{0, 1, ..., |\text{data}| - 1\}$,
+            and the values are each one of the $k$ entries in `data`.
 
     Examples
     --------


### PR DESCRIPTION
Add two simple data conversion utility functions:

* `numpy2dict`: convert an one-dimensional numpy array to a dictionary
* `dict2numpy`: convert a dictionary containing only numerical data as its values to an one-dimensional numpy array

Note that the building process is being fixed in #319. Once this PR is merged, I should do a rebase to make sure everything is working as intended.