### PR TITLE
Performance improvements for VectorDict

### DIFF
--- a/creme/utils/test_vectordict.py
+++ b/creme/utils/test_vectordict.py
@@ -89,18 +89,18 @@ def test_vectordict():
     assert x['f'] == 2
 
     # test mask
-    x = {'a': 1, 'b': -5}
+    x = {'a': 1, 'b': -5, 'e': 2}
     y = {'b': 0.5, 'd': 4, 'e': 3, 'f': 8}
     z = {'b': 4, 'd': 2, 'g': -1}
     vx = VectorDict(x)
     vy = VectorDict(y)
-    assert vx + vy == {'a': 1, 'b': -4.5, 'd': 4, 'e': 3, 'f': 8}
+    assert vx + vy == vy + vx == {'a': 1, 'b': -4.5, 'd': 4, 'e': 5, 'f': 8}
     vy = VectorDict(y, mask=z)
-    assert vx + vy == {'a': 1, 'b': -4.5, 'd': 4}
+    assert vx + vy == vy + vx == {'a': 1, 'b': -4.5, 'd': 4, 'e': 2}
     vy = VectorDict(y).with_mask(z.keys())
-    assert vx + vy == {'a': 1, 'b': -4.5, 'd': 4}
+    assert vx + vy == vy + vx == {'a': 1, 'b': -4.5, 'd': 4, 'e': 2}
     vy = VectorDict(y).with_mask(x)
-    assert vy / vx == {'b': -0.1, 'a': 0.0}
+    assert vy / vx == {'b': -0.1, 'a': 0.0, 'e': 1.5}
 
     # test export
     x = {'a': 1, 'b': -5}

--- a/creme/utils/vectordict.pyx
+++ b/creme/utils/vectordict.pyx
@@ -28,7 +28,11 @@ cdef inline get_keys(VectorDict vec):
 cdef inline get_union_keys(VectorDict left, VectorDict right):
     left_keys = get_keys(left)
     right_keys = get_keys(right)
-    right_only_keys = itertools.filterfalse(left._data.__contains__, right_keys)
+    if left._lazy_mask:
+        right_only_keys = (key for key in right_keys
+                           if key not in left._data or key not in left._mask)
+    else:
+        right_only_keys = (key for key in right_keys if key not in left._data)
     return itertools.chain(left_keys, right_only_keys)
 
 


### PR DESCRIPTION
Implements a fast track for dot products when only the intersection of the keys is needed.
Also a bug fix for cases with mask.
This addresses concerns of [low performance](https://github.com/creme-ml/creme/pull/316#issuecomment-684126028) shared by @gbolmier, below is updated benchmarks in this branch.

```py
from creme import utils

x = {i: i for i in range(100)}
xx = {i: i for i in range(1_000)}
y = utils.VectorDict(x)
yy = utils.VectorDict(xx)

%timeit utils.math.dot(x, x)
# 12.2 µs ± 120 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

%timeit utils.math.dot(xx, x)
# 12.1 µs ± 95.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

%timeit y @ y
# 8.93 µs ± 126 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

%timeit yy @ y
# 8.93 µs ± 102 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```